### PR TITLE
Check for net-tools for ifconfig

### DIFF
--- a/redonion_bootstrap_7.sh
+++ b/redonion_bootstrap_7.sh
@@ -183,7 +183,7 @@ source /etc/profile
 
   # Make sure net-tools is installed on centos for ifconfig
   if [ -f /etc/centos-release ]; then
-    if [[ ! `yum repolist | grep net-tools | awk '{ print $1 }'` ]]; then
+    if [[ ! `yum list installed | grep net-tools | awk '{ print $1 }'` ]]; then
         print_status "net-tools not found, installing for ifconfig..."
         sudo yum -y install net-tools
         handle_error

--- a/redonion_bootstrap_7.sh
+++ b/redonion_bootstrap_7.sh
@@ -180,6 +180,15 @@ source /etc/profile
         handle_error
     fi
   fi
+
+  # Make sure net-tools is installed on centos for ifconfig
+  if [ -f /etc/centos-release ]; then
+    if [[ ! `yum repolist | grep net-tools | awk '{ print $1 }'` ]]; then
+        print_status "net-tools not found, installing for ifconfig..."
+        sudo yum -y install net-tools
+        handle_error
+    fi
+  fi
   
   # Check to make sure that the user that we are running as and dropping permissions to exists
   if id -u "$user_drop" >/dev/null 2>&1; then


### PR DESCRIPTION
On lines 246, 254, and 256, there are commands that use `ifconfig`. This is not installed on a minimal install. I simply copied your `epel` check for `net-tools` which provides `ifconfig`. 