### PR TITLE
Give full path to luarocks

### DIFF
--- a/redonion_bootstrap_7.sh
+++ b/redonion_bootstrap_7.sh
@@ -887,11 +887,11 @@ function suricata ()
     handle_error
     cd ..
 
-    luarocks install struct 
+    /usr/local/bin/luarocks install struct 
     handle_error
-    luarocks install lua-apr 
+    /usr/local/bin/luarocks install lua-apr 
     handle_error
-    luarocks install luazip 
+    /usr/local/bin/luarocks install luazip 
     handle_error
 
     # LUA ZLIB


### PR DESCRIPTION
Since `luarocks` is not in the `$PATH` after we install it via the bootstrap, let's just call it from where it installed to: `/usr/local/bin/luarocks`. Without this, the bootstrap will fail when `luarocks` is called on line 899. 